### PR TITLE
Add some english names for Tingle Tuner-related actors

### DIFF
--- a/Editor/resources/ActorDatabase.json
+++ b/Editor/resources/ActorDatabase.json
@@ -345,7 +345,7 @@
     "ActorClassType": "agbsw0",
     "Wait Animations": null,
     "Actor Name": "agbR",
-    "English Name": "agbsw0",
+    "English Name": "Tingle Secret Item Drop",
     "Tags": null,
     "Explanation": null,
     "Locations": [
@@ -366,7 +366,7 @@
     "ActorClassType": "agbsw0",
     "Wait Animations": null,
     "Actor Name": "agbB",
-    "English Name": "agbsw0",
+    "English Name": "Tingle Tuner Item Restriction",
     "Tags": null,
     "Explanation": null,
     "Locations": [
@@ -390,7 +390,7 @@
     "ActorClassType": "agbsw0",
     "Wait Animations": null,
     "Actor Name": "agbD",
-    "English Name": "agbsw0",
+    "English Name": "Tingle Tuner Cursor Stuck",
     "Tags": null,
     "Explanation": null,
     "Locations": [


### PR DESCRIPTION
agbR are secret item drops. Hover over them with the tuner cursor to make an exclamation mark appear and press A to reveal an item.
agbB are areas that restrict some tuner item uses (generally tingle bombs).
agbD are areas where the cursor gets stuck. If you go through the cursor with Link you gain a reward.